### PR TITLE
Test on python3.12 and python3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/src/mps/plotter.py
+++ b/src/mps/plotter.py
@@ -62,7 +62,7 @@ def set_mpl_options(**kwargs):
         return
 
     mpl.rcParams["savefig.format"] = kwargs.pop("save_format", "pdf")
-    from distutils.spawn import find_executable
+    from shutil import which as find_executable
 
     if find_executable("latex"):
         mpl.rcParams["text.usetex"] = kwargs.pop("usetex", True)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,8 +1,7 @@
 import shutil
 import subprocess as sp
 from pathlib import Path
-
-from distutils.spawn import find_executable
+from shutil import which as find_executable
 
 import mps
 


### PR DESCRIPTION
Remove `distutils` dependency which was deprecated in python3.12